### PR TITLE
upgrade to 2.7.2; add install script to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ If you'd like to attempt to experience latest features, you also can build from 
 1. Maven install current project in your local repository.
 > Maven install = `mvn install`
 
-
+```bash
+./mvnw clean install -DskipTests
+```
 
 
 ## Getting Started

--- a/README_CN.md
+++ b/README_CN.md
@@ -115,6 +115,9 @@
 1. Maven install 当前工程
 > Maven install = `mvn install`
 
+```bash
+./mvnw clean install -DskipTests
+```
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <maven_javadoc_version>3.0.1</maven_javadoc_version>
         <maven_surefire_version>2.19.1</maven_surefire_version>
-        <revision>2.7.1</revision>
+        <revision>2.7.2</revision>
     </properties>
 
     <modules>


### PR DESCRIPTION
Latest release version of Dubbo and dubbo-admin are 2.7.2 while lastest release version of dubbo-spring-boot-starter is still 2.7.1. It should be upgraded.