### PR TITLE
解决flatten-maven-plugin在Eclipse下报错问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,33 +159,35 @@
     </profiles>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.1.0</version>
-                <configuration>
-                    <updatePomFile>true</updatePomFile>
-                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>flatten</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>flatten.clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+	    <pluginManagement>
+	        <plugins>
+	            <plugin>
+	                <groupId>org.codehaus.mojo</groupId>
+	                <artifactId>flatten-maven-plugin</artifactId>
+	                <version>1.1.0</version>
+	                <configuration>
+	                    <updatePomFile>true</updatePomFile>
+	                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+	                </configuration>
+	                <executions>
+	                    <execution>
+	                        <id>flatten</id>
+	                        <phase>process-resources</phase>
+	                        <goals>
+	                            <goal>flatten</goal>
+	                        </goals>
+	                    </execution>
+	                    <execution>
+	                        <id>flatten.clean</id>
+	                        <phase>clean</phase>
+	                        <goals>
+	                            <goal>clean</goal>
+	                        </goals>
+	                    </execution>
+	                </executions>
+	            </plugin>
+	        </plugins>
+        </pluginManagement>
     </build>
 
 </project>


### PR DESCRIPTION
Plugin execution not covered by lifecycle configuration: org.codehaus.mojo:flatten-maven-plugin:1.1.0:flatten (execution: flatten, phase: process-resources)	pom.xml	/dubbo-spring-boot-registry-zookeeper-consumer-sample	line 21	Maven Project Build Lifecycle Mapping Problem
在Eclipse下有上面错误，IntelliJ IDEA下是没有问题的，具体解决方案可以参考下面链接
https://stackoverflow.com/questions/6352208/how-to-solve-plugin-execution-not-covered-by-lifecycle-configuration-for-sprin
