### PR TITLE
fix link from Chinese README to the English one

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -13,7 +13,7 @@
 > Apache Dubbo  |ˈdʌbəʊ| 是一款高性能、轻量级的开源Java RPC框架，它提供了三大核心能力：面向接口的远程方法调用，智能容错和负载均衡，以及服务自动注册和发现。
 
 
-## [English README](README_CN.md)
+## [English README](README.md)
 
 
 ## 已发行版本


### PR DESCRIPTION
The link of `English README` now lead to `README_CN.md`, it should be `README.md`.