### PR TITLE
解决当yaml文件中dubbo.scan.base-packages属性以数组方式进行配置时无法读取该配置的bug。

### DIFF
--- a/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/util/DubboUtils.java
+++ b/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/util/DubboUtils.java
@@ -72,6 +72,13 @@ public abstract class DubboUtils {
     public static final String BASE_PACKAGES_PROPERTY_NAME = "base-packages";
 
     /**
+     * The property name of base packages to scan
+     * <p>
+     * The default value is empty set.
+     */
+    public static final String BASE_PACKAGES_ARRAY_PROPERTY_NAME = "base-packages[0]";
+
+    /**
      * The property name of multiple properties binding from externalized configuration
      * <p>
      * The default value is {@link #DEFAULT_MULTIPLE_CONFIG_PROPERTY_VALUE}


### PR DESCRIPTION
当application.yml配置文件配置如下时，会出现无法正常读取dubbo.scan.base-packages属性：
```
dubbo:
    scan:
        base-packages: 
          - com.tft.account.core.service
```
因为在此情况下，以下代码无法准确判断条件是否满足：
```
@ConditionalOnProperty(
        prefix = "dubbo.scan.",
        name = {"base-packages"}
    )
```
此次PR增加读取dubbo.scan.base-packages[0]属性的罗辑，当二者满足其一则正常加载该配置。