### PR TITLE
fix readme_cn

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -288,8 +288,8 @@ Dubbo Spring Boot 示例工程包括:
 
 - [自动装配](dubbo-spring-boot-samples/auto-configure-samples)
 - [外部化配置](dubbo-spring-boot-samples/externalized-configuration-samples)
-- [Zookeeper 注册中心](dubbo-spring-boot-samples/dubbo-registry-zookeeper-samples)
-- [Nacos 注册中心](dubbo-spring-boot-samples/dubbo-registry-nacos-samples)
+- [Zookeeper 注册中心](https://github.com/apache/dubbo-spring-boot-project/tree/master/dubbo-spring-boot-samples/registry-samples/zookeeper-samples)
+- [Nacos 注册中心](https://github.com/apache/dubbo-spring-boot-project/tree/master/dubbo-spring-boot-samples/registry-samples/nacos-samples)
 
 
 


### PR DESCRIPTION
fix readme_cn
Registry Zookeeper Samples  link to `https://github.com/apache/dubbo-spring-boot-project/tree/master/dubbo-spring-boot-samples/registry-samples/zookeeper-samples`
Registry Nacos Samples link to `https://github.com/apache/dubbo-spring-boot-project/tree/master/dubbo-spring-boot-samples/registry-samples/nacos-samples`